### PR TITLE
Fix: Add types to fibonacci function

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This pull request resolves Issue #1 by adding explicit TypeScript types to the `fibonacci` function in `src/fib.ts`.

**Changes Made:**
* The function parameter `n` is now explicitly typed as a `number`.
* The function's return value is now explicitly typed as a `number`.
* These changes resolve all the `no-unsafe-return` and `restrict-plus-operands` linting errors for this file.

**Testing:**
* Verified locally by running `npm run lint` and `npm run test` commands which now show no errors for `src/fib.ts` and `src/fibRoute.ts` files.
