### PR TITLE
Fix: Add Express types to fibRoute handler

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,8 @@
 // Endpoint for querying the fibonacci numbers
-
 import fibonacci from "./fib";
+import { Request, Response } from "express";
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
This pull request resolves Issue #2 by adding the correct Express types to the route handler in `src/fibRoute.ts`.

**Changes Made:**
* Imported the `Request` and `Response` types from the `express` library.
* Applied these types to the `req` and `res` parameters of the handler function.
* This resolves all remaining `no-unsafe-assignment` and `restrict-template-expressions` linting errors.

**Testing:**
* Verified locally by running `npm run lint` and `npm run test` commands which now show no errors for `src/fib.ts` and `src/fibRoute.ts` files.